### PR TITLE
Bug fix: Faq accordion would stop working after searches

### DIFF
--- a/fireapp/static/fireapp/js/faq.js
+++ b/fireapp/static/fireapp/js/faq.js
@@ -1,17 +1,18 @@
-let questions = document.getElementsByClassName("questions");
-// console.log("Hello World");
-for (let i = 0; i < questions.length; i++) {
-	questions[i].addEventListener("click", function () {
-		this.classList.toggle("is-open");
-		let content = this.nextElementSibling;
-		if (content.style.maxHeight) {
-			// if truthy set to falsey
-			// set height value to zero or null
-			content.style.maxHeight = null;
-		} else {
-			// if closed (falsey) set to truthy
-			// Set max height === content height on screen
-			content.style.maxHeight = content.scrollHeight + "px";
-		}
-	});
-}
+let questions = document.querySelector(".accordian");
+// targeting the div containing the questions
+
+questions.addEventListener("click", (e) => {
+	// event parameter captures the event
+	e.target.classList.toggle("is-open");
+	//event.target figures out what element within the div was clicked
+	let content = e.target.nextElementSibling;
+	if (content.style.maxHeight) {
+		// if truthy set to falsey
+		// set height value to zero or null
+		content.style.maxHeight = null;
+	} else {
+		// if closed (falsey) set to truthy
+		// Set max height === content height on screen
+		content.style.maxHeight = content.scrollHeight + "px";
+	};
+});


### PR DESCRIPTION
After searches, event listeners targeting questions would disappear. 
Made the listener target the parent div instead.